### PR TITLE
Do not append 14 random bytes to raw packets

### DIFF
--- a/buildroot-external-xaptum/patches/linux/4.14.47/0005-fix-reserve-calculation.patch
+++ b/buildroot-external-xaptum/patches/linux/4.14.47/0005-fix-reserve-calculation.patch
@@ -1,0 +1,13 @@
+diff --git a/net/packet/af_packet.c b/net/packet/af_packet.c
+index e9422fe45179..acb7b86574cd 100644
+--- a/net/packet/af_packet.c
++++ b/net/packet/af_packet.c
+@@ -2911,7 +2911,7 @@  static int packet_snd(struct socket *sock, struct msghdr *msg, size_t len)
+ 		if (unlikely(offset < 0))
+ 			goto out_free;
+ 	} else if (reserve) {
+-		skb_push(skb, reserve);
++		skb_reserve(skb, -reserve);
+ 	}
+ 
+ 	/* Returns -EFAULT on error */


### PR DESCRIPTION
When injecting a raw packet into the eth0 interface of len X, and
verifying what I had captured on my host using Wireshark, I could see
that X+14 bytes were being captured. Random bytes were being added.

Apparently this problem was introduced by the patch below:

https://stackoverflow.com/questions/52435788/why-are-14-bytes-of-random-data-appended-to-a-raw-ethernet-frame

This patch fixes the problem introduced with the new patch.

See http://patchwork.ozlabs.org/patch/920126/