### PR TITLE
amcl: change remote url to Xaptum fork

### DIFF
--- a/buildroot-external-xaptum/package/amcl/amcl.mk
+++ b/buildroot-external-xaptum/package/amcl/amcl.mk
@@ -5,7 +5,7 @@
 ################################################################################
 
 AMCL_VERSION = 4.7.0
-AMCL_SITE = $(call github,milagro-crypto,milagro-crypto-c,$(AMCL_VERSION))
+AMCL_SITE = $(call github,xaptum,amcl,$(AMCL_VERSION))
 AMCL_LICENSE = Apache-2.0
 AMCL_LICENSE_FILES = LICENSE
 AMCL_INSTALL_STAGING = YES


### PR DESCRIPTION
Miracl has moved future development of AMCL in-house and removed the
already-open sourced code from the milagro-crypto Github.  So, point
at the Xaptum fork instead.