### PR TITLE
enftun: upgrade to version 0.3.4

### DIFF
--- a/buildroot-external-xaptum/package/enftun/enftun.hash
+++ b/buildroot-external-xaptum/package/enftun/enftun.hash
@@ -1,2 +1,2 @@
 # Locally computed
-sha256 f905d3397600bc4b40426b6468f3aca6332998f34b2c4bb1de3882c39d7d5711 enftun-v0.3.3.tar.gz
+sha256 594cdde688beaf462d53924d90fb3a25f9959b7d4fbb48a6134353ff71c455ca enftun-v0.3.4.tar.gz

--- a/buildroot-external-xaptum/package/enftun/enftun.mk
+++ b/buildroot-external-xaptum/package/enftun/enftun.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-ENFTUN_VERSION = v0.3.3
+ENFTUN_VERSION = v0.3.4
 ENFTUN_SITE = $(call github,xaptum,enftun,$(ENFTUN_VERSION))
 ENFTUN_LICENSE = Apache-2.0
 ENFTUN_LICENSE_FILES = LICENSE


### PR DESCRIPTION
This upgrade enables TCP keepalives to detect dead connections and
fixes an an error-handling bug that can lead to deadlock.