### PR TITLE
xaprw: order xap-usb-gadget after wlan- is up mac address is set

### DIFF
--- a/buildroot-external-xaptum/board/xaprw001/rootfs_overlay/etc/systemd/system/xap-usb-gadget.service.d/50-after-macset.conf
+++ b/buildroot-external-xaptum/board/xaprw001/rootfs_overlay/etc/systemd/system/xap-usb-gadget.service.d/50-after-macset.conf
@@ -1,0 +1,3 @@
+[Unit]
+After=macset@wlan0.service
+After=sys-subsystem-net-devices-wlan0.device


### PR DESCRIPTION
xap-usb-gadget reads the MAC address from wlan0, so make sure that it is available before starting.

This is a temporary fix.  My forthcoming PR to switch from `g_ether` to configfs should fix this entirely.