### PR TITLE
enftun: upgrade to version 0.4.2

### DIFF
--- a/buildroot-external-xaptum/package/enftun/enftun.hash
+++ b/buildroot-external-xaptum/package/enftun/enftun.hash
@@ -1,2 +1,2 @@
 # Locally computed
-sha256 e2e9ee0b7662615cc235cfb2c789bd8deef861b80ef7e480d2b4aa76fd1ff1ac enftun-v0.4.1.tar.gz
+sha256 0a08b277005b5215f1cf26342964078c515f6058892218daab652afb8d6006e6 enftun-v0.4.2.tar.gz

--- a/buildroot-external-xaptum/package/enftun/enftun.mk
+++ b/buildroot-external-xaptum/package/enftun/enftun.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-ENFTUN_VERSION = v0.4.1
+ENFTUN_VERSION = v0.4.2
 ENFTUN_SITE = $(call github,xaptum,enftun,$(ENFTUN_VERSION))
 ENFTUN_LICENSE = Apache-2.0
 ENFTUN_LICENSE_FILES = LICENSE


### PR DESCRIPTION
Upgrades `enftun` to a version that contains a workaround for old versions of `connman` that do not properly handle infinite lifetimes in DHCP6 leases.