### PR TITLE
xtt: upgrade to version 0.10.5

### DIFF
--- a/buildroot-external-xaptum/package/xtt/xtt.hash
+++ b/buildroot-external-xaptum/package/xtt/xtt.hash
@@ -1,2 +1,2 @@
 # Locally computed
-sha256 610640ac48c82f7f059a3d47332876b62ad2d9be5b12ffcd7eb28572cc17ec3d xtt-v0.10.4.tar.gz
+sha256 8d28bb204efabf54bd23b8d3aeb25334c4f9dc8e7654e739491304733f193949 xtt-v0.10.5.tar.gz

--- a/buildroot-external-xaptum/package/xtt/xtt.mk
+++ b/buildroot-external-xaptum/package/xtt/xtt.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-XTT_VERSION = v0.10.4
+XTT_VERSION = v0.10.5
 XTT_SITE = $(call github,xaptum,xtt,$(XTT_VERSION))
 XTT_LICENSE = Apache-2.0
 XTT_LICENSE_FILES = LICENSE


### PR DESCRIPTION
Fixes issue where xtt would not completely overwrite the cert or key
files.