### PR TITLE
wpa-credentials: upgrade to restrict interfaces for connman

### DIFF
--- a/buildroot-external-xaptum/package/wpa-credentials/wpa-credentials.mk
+++ b/buildroot-external-xaptum/package/wpa-credentials/wpa-credentials.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-WPA_CREDENTIALS_VERSION = 6f2325e2185cc798858fe15191bbeeacf86dcdad
+WPA_CREDENTIALS_VERSION = 086c955ed46dbfbd8ad9eeaadffa577c9eaea4e4
 WPA_CREDENTIALS_SITE = ssh://git@github.com/xaptum/xaprc.git
 WPA_CREDENTIALS_SITE_METHOD = git
 WPA_CREDENTIALS_SUPPORTS_IN_SOURCE_BUILD = NO


### PR DESCRIPTION
By default, connman will try to control the usb0, enf0, and enf1 interfaces. This can occasionally cause problems.  This version of wpa-credentials configures connman to ignore those interfaces.